### PR TITLE
replace oDb->getAssoc by oDb->getRow

### DIFF
--- a/copy_this/modules/bla/tag-manager/application/files/blatm_events.php
+++ b/copy_this/modules/bla/tag-manager/application/files/blatm_events.php
@@ -19,7 +19,7 @@ class blatm_events extends oxI18n
     {
         /** @var oxLegacyDb $oDb */
         $oDb = oxDb::getDB();
-        $aColumns = $oDb->getAssoc("SHOW COLUMNS FROM oxorder");
+        $aColumns = $oDb->getRow("SHOW COLUMNS FROM oxorder");
 
         // rename BLAREFERRER column -> BLAHTTPREF or create new
         if( array_key_exists( "BLAREFERRER", $aColumns )) $oDb->Execute("ALTER TABLE `oxorder` CHANGE `BLAREFERRER` `BLAHTTPREF` TEXT NOT NULL COMMENT 'bla/tag-manager http ref'");

--- a/copy_this/modules/bla/tag-manager/application/files/blatracking_events.php
+++ b/copy_this/modules/bla/tag-manager/application/files/blatracking_events.php
@@ -29,7 +29,7 @@ class blatracking_events extends oxI18n {
     {
         /** @var oxLegacyDb $oDb */
         $oDb = oxDb::getDB();
-        $aColumns = $oDb->getAssoc("SHOW COLUMNS FROM oxorder");
+        $aColumns = $oDb->getRow("SHOW COLUMNS FROM oxorder");
 
         // rename BLAREFERRER column or create new
 		if( array_key_exists( "BLAREFERRER", $aColumns )) $oDb->Execute("ALTER TABLE `oxorder` CHANGE `BLAREFERRER` `BLAHTTPREF` TEXT NOT NULL COMMENT 'bla-tracking http ref'");


### PR DESCRIPTION
`getAssoc` was deprecated in OXID 4.10 and was removed in OXID 6.